### PR TITLE
Require only actually used attributes and classes in "requiredContent" property

### DIFF
--- a/footnotes/plugin.js
+++ b/footnotes/plugin.js
@@ -116,7 +116,7 @@
             editor.addCommand('footnotes', new CKEDITOR.dialogCommand('footnotesDialog', {
                 // @TODO: This needs work:
                 allowedContent: 'section[*](*);header[*](*);li[*];a[*];cite(*)[*];sup[*]',
-                requiredContent: 'section[*](*);header[*](*);li[*];a[*];cite(*)[*];sup[*]'
+                requiredContent: 'section(footnotes);header;li[id,data-footnote-id];a[href,id,rel];cite;sup[data-footnote-id]'
             }));
 
             // Create a toolbar button that executes the above command.


### PR DESCRIPTION
Currently plugin requires all tags and attributes on tags that it uses (`section`, `header`, `li`, `a`,  `cite`, `sup`). This change limits the attributes and classes to attributes and classes that the plugin actually uses:
- `section(footnotes)`
- `header `
- `li[id,data-footnote-id]`
- `a[href,id,rel]`
- `cite `
- `sup[data-footnote-id]`