### PR TITLE
Re-layout dialog after textarea is loaded to fix scroll behaviour

### DIFF
--- a/footnotes/dialogs/footnotes.js
+++ b/footnotes/dialogs/footnotes.js
@@ -96,10 +96,6 @@
                     dialog.editor_name = evt.editor.name;
                 } );
 
-                // Allow page to scroll with dialog to allow for many/long footnotes
-                // (https://github.com/andykirk/CKEditorFootnotes/issues/12)
-                jQuery('.cke_dialog').css({'position': 'absolute', 'top': '2%'});
-
                 var current_editor_id = dialog.getParentEditor().id;
 
                 CKEDITOR.replaceAll( function( textarea, config ) {
@@ -129,6 +125,11 @@
                     config.removePlugins = 'footnotes';
 
                     config.on = {
+                        // Re-layout dialog after textarea is loaded to fix scroll behaviour
+                        // (https://github.com/andykirk/CKEditorFootnotes/issues/12)
+                        instanceReady: function() {
+                            dialog.layout();
+                        },
                         focus: function( evt ){
                             var $editor_el = $('#' + evt.editor.id + '_contents');
                             $editor_el.parents('tr').next().find(':checked').attr('checked', false);


### PR DESCRIPTION
Regarding https://github.com/andykirk/CKEditorFootnotes/issues/12

CKEditor handles the position of the dialog correctly even if the viewport is smaller than the dialog.
The problem was that the initialization of the footnote's CKEditor changed the height of the dialog after the dialog's layouting. If that happens, a re-layout of the dialog is necessary to fix the position of the dialog.