### PR TITLE
Add a config option to provide extra config to the footnote editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ E.g.
 ~~~
 CKEDITOR.replace( 'editor1', {
     footnotesHeaderEls: ['<p><b>', '</b></p>'], // Defaults to ['<h2>', '</h2>']
-    footnotesTitle: 'References' // Defaults to 'Footnotes'
+    footnotesTitle: 'References', // Defaults to 'Footnotes'
+    footnotesDialogEditorExtraConfig: { height: 150 } // Will be merged with the default options for the footnote editor
 } );
 ~~~
 

--- a/footnotes/dialogs/footnotes.js
+++ b/footnotes/dialogs/footnotes.js
@@ -150,6 +150,13 @@
                     config.autoGrow_minHeight = 80;
                     config.removePlugins = 'footnotes';
 
+                    var extra_config = editor.config.footnotesDialogEditorExtraConfig;
+                    if (extra_config) {
+                        for (var attribute in extra_config) {
+                            config[attribute] = extra_config[attribute];
+                        }
+                    }
+
                     // If we focus on the dialog editor we should clear the radios to avoid any
                     // confusion. Similarly, if we focus on a radio, we should clear the editor
                     // (see setup above for radio change event handler for that)


### PR DESCRIPTION
The extra config will be merged with the values that are set by default by the plugin.